### PR TITLE
Difference between a white background and map is too big

### DIFF
--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -9,6 +9,7 @@ body {
   top: 0;
   bottom: 0;
   width: 100%;
+  background-color: #000;
 }
 
 .vingette {


### PR DESCRIPTION
The transition between the white background and the map is not very smooth as demonstrated here: http://cl.ly/2s1F2s1r3h1e 

I think it'd be nice to have the tab start with a dark background so when the map loads, the difference won't be as drastic, and you'd also be able to see the time clearly. Kind of like what y'all have on https://www.mapbox.com/design/ ->

![image](https://cloud.githubusercontent.com/assets/1153134/7641520/d54e4210-fabc-11e4-8613-2861cb3f38f2.png)

(Obviously here, it'd be better if we can use the same color palette as the map, and not just `#000`. You'd probably have a better idea how to achieve that.)
